### PR TITLE
Upgrade the max FPS

### DIFF
--- a/pyartnet/artnet_node.py
+++ b/pyartnet/artnet_node.py
@@ -45,7 +45,7 @@ class ArtNetNode:
 
         self.__task = None
 
-        max_fps = max(1, min(max_fps, 40))
+        max_fps = max(1, min(max_fps, 44))
         self.sleep_time = 1 / max_fps
 
         self.refresh_every = refresh_every


### PR DESCRIPTION
The max framerate of DMX streaming protocols is 44, not 40. The default is already 25; if the user of the API requests more than 40, why not let them?