### PR TITLE
Fix issue 25

### DIFF
--- a/pyartnet/artnet_node.py
+++ b/pyartnet/artnet_node.py
@@ -14,6 +14,11 @@ log = logging.getLogger('pyartnet.ArtNetNode')
 
 
 class ArtNetNode:
+    # The maximum 44fps is for DMX512 with full 512 channels.
+    # More is possible with less channels in a universe or with other
+    # ArtNet controllers e.g. for some LED strips output protocols.
+    MAX_FPS = 44
+
     def __init__(self, host: str, port: int = 0x1936, max_fps: int = 25,
                  refresh_every: int = 2, sequence_counter: bool = True, broadcast: bool = False):
         """
@@ -45,8 +50,7 @@ class ArtNetNode:
 
         self.__task = None
 
-        # Maximum fps for DMX is 44fps, more makes no sense
-        max_fps = max(1, min(max_fps, 44))
+        max_fps = max(1, min(max_fps, self.MAX_FPS))
         self.sleep_time = 1 / max_fps
 
         self.refresh_every = refresh_every

--- a/pyartnet/artnet_node.py
+++ b/pyartnet/artnet_node.py
@@ -68,7 +68,7 @@ class ArtNetNode:
 
     async def __worker(self):
         log.debug('Worker started')
-        last_update = time.time()
+        last_update = 0.0
 
         while True:
             await asyncio.sleep(self.sleep_time)

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from itertools import zip_longest
 from unittest.mock import Mock
@@ -207,3 +208,15 @@ def test_channel_max_values():
     univ.add_channel(20, 1, channel_type=pyartnet.DmxChannel16Bit).add_fade([0xFFFF], 0)
     univ.add_channel(30, 1, channel_type=pyartnet.DmxChannel24Bit).add_fade([0xFFFFFF], 0)
     univ.add_channel(40, 1, channel_type=pyartnet.DmxChannel32Bit).add_fade([0xFFFFFFFF], 0)
+
+
+@pytest.mark.asyncio
+async def test_can_turn_lights_off(running_artnet_node: PatchedArtNetNode):
+
+    # check that a zero packet is sent initially if a zero fade or no fade is used
+    running_artnet_node.refresh_every = 2
+    universe = running_artnet_node.add_universe(0)
+    channel = universe.add_channel(1, 1)
+    channel.add_fade([0], 0)  # empty fade is not important to can turn lights off
+    await asyncio.sleep(0.01)
+    assert running_artnet_node.values == [[0, 0]]

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
 envlist =
-    py37
     py38
     py39
+    py310
     flake
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38, flake
     3.9: py39
+    3.10: py310
 
 [testenv]
 deps =


### PR DESCRIPTION
Three commits for three issues:

- Can not turn lights off initially: a simple fix by zero `last_update` time. Even if no fade is started initially a it is a fade to zero intensity then the zero status is sent  by the first packed because the `last_update` is old. Added a test for #25 .
- Removed unsupported Python 3.7 from tests and added Python 3.10.
- Added a configurable limit MAX_FPS because 44 fps is related only to full number of 512 channels in a universe. Some ArtNet controllers that directly control LED strips without conversion to DMX512 protocol can work on a higher frequency. This can be configured e.g. by `from pyartnet import ArtNetNode` and `setattr(ArtNetNode, 'MAX_FPS', 50)`.  
(It is important to read this frequency from device documentation and not empirical by PyArtNet because the current implementation only ensures by an additional sleep delay that the frequency is not higher, but the `process()` method itself can be slow if the number of universes and channels is high. It is not easy to compensate it easily without any of possible undesirable side effects. Therefore I keep it simple.)