### PR TITLE
Sync universes

### DIFF
--- a/src/pyartnet/base/base_node.py
+++ b/src/pyartnet/base/base_node.py
@@ -67,6 +67,12 @@ class BaseNode(Generic[TYPE_U], OutputCorrection):
     def _send_universe(self, id: int, byte_size: int, values: bytearray, universe: TYPE_U):
         raise NotImplementedError()
 
+    def set_synchronous_mode(self, enabled: bool):
+        raise NotImplementedError()
+
+    def _send_synchronization(self):
+        pass
+
     def _send_data(self, data: Union[bytearray, bytes]) -> int:
 
         ret = self._socket.sendto(self._packet_base + data, self._dst)
@@ -103,6 +109,8 @@ class BaseNode(Generic[TYPE_U], OutputCorrection):
                     self._process_jobs.remove(job)
                     job.fade_complete()
 
+            self._send_synchronization()
+
             await sleep(self._process_every)
 
     def start_refresh(self):
@@ -127,6 +135,8 @@ class BaseNode(Generic[TYPE_U], OutputCorrection):
 
             for u in self._universes:
                 u.send_data()
+
+            self._send_synchronization()
 
     def get_universe(self, nr: int) -> TYPE_U:
         """Get universe by number

--- a/src/pyartnet/impl_artnet/node.py
+++ b/src/pyartnet/impl_artnet/node.py
@@ -35,23 +35,26 @@ class ArtNetNode(BaseNode['pyartnet.impl_artnet.ArtNetUniverse']):
         packet = bytearray()
         packet.extend(map(ord, "Art-Net"))
         packet.append(0x00)          # Null terminate Art-Net
-        packet.extend([0x00, 0x50])  # Opcode ArtDMX 0x5000 (Little endian)
-        packet.extend([0x00, 0x0e])  # Protocol version 14
         self._packet_base = bytes(packet)
+
+        self._sync_enabled : bool = False
 
     def _send_universe(self, id: int, byte_size: int, values: bytearray,
                        universe: 'pyartnet.impl_artnet.ArtNetUniverse'):
 
         # pre allocate the bytearray
-        _size = 6 + byte_size
+        _size = 10 + byte_size
         packet = bytearray(_size)
 
-        packet[0] = self._sequence_ctr.value                    # 1 | Sequence,
-        packet[1] = 0x00                                        # 1 | Physical input port (not used)
-        packet[2:4] = id.to_bytes(2, byteorder='little')        # 2 | Universe
+        packet[0:2] =[0x00, 0x50]  # Opcode ArtDMX 0x5000 (Little endian)
+        packet[2:4] = [0x00, 0x0e]  # Protocol version 14
 
-        packet[4:6] = byte_size.to_bytes(2, 'big')              # 2       | Number of channels Big Endian
-        packet[6: _size] = values                               # 0 - 512 | Channel values
+        packet[4] = self._sequence_ctr.value                    # 1 | Sequence,
+        packet[5] = 0x00                                        # 1 | Physical input port (not used)
+        packet[6:8] = id.to_bytes(2, byteorder='little')        # 2 | Universe
+
+        packet[8:10] = byte_size.to_bytes(2, 'big')              # 2       | Number of channels Big Endian
+        packet[10: _size] = values                               # 0 - 512 | Channel values
 
         self._send_data(packet)
 
@@ -129,3 +132,25 @@ class ArtNetNode(BaseNode['pyartnet.impl_artnet.ArtNetUniverse']):
         if show_description:
             log.debug(out_desc)
         log.debug(out)
+
+    def set_synchronous_mode(self, enabled: bool):
+        self._sync_enabled = enabled
+
+    def _send_synchronization(self):
+        if not self._sync_enabled:
+            return
+
+        # pre allocate the bytearray
+        packet = bytearray(6)
+
+        packet[0:2] = [0x00, 0x52]  # Opcode ArtSync
+        packet[2:4] = [0x00, 0x0e]  # Protocol version 14
+
+        packet[4] = 0               # Aux1
+        packet[5] = 0               # Aux2
+
+        self._send_data(packet)
+
+        # log complete packet
+        if log.isEnabledFor(logging.DEBUG):
+            self.__log_artnet_frame(self._packet_base + packet)

--- a/src/pyartnet/impl_sacn/node.py
+++ b/src/pyartnet/impl_sacn/node.py
@@ -21,7 +21,9 @@ ACN_PACKET_IDENTIFIER: Final = (0x41, 0x53, 0x43, 0x2d, 0x45, 0x31, 0x2e, 0x31, 
 
 # Field constants
 VECTOR_ROOT_E131_DATA: Final = b'\x00\x00\x00\x04'
+VECTOR_ROOT_E131_EXTENDED: Final = b'\x00\x00\x00\x08'
 VECTOR_E131_DATA_PACKET: Final = b'\x00\x00\x00\x02'
+VECTOR_E131_EXTENDED_SYNCHRONIZATION: Final = b'\x00\x00\x00\x01'
 VECTOR_DMP_SET_PROPERTY: Final = 0x02
 
 
@@ -52,6 +54,7 @@ class SacnNode(BaseNode['pyartnet.impl_sacn.SacnUniverse']):
         source_name_byte = source_name.encode('utf-8').ljust(64, b'\x00')
         if len(source_name_byte) > 64:
             raise ValueError('Source name too long!')
+        self._source_name_byte : bytes = source_name_byte
 
         # build base packet
         packet = bytearray()
@@ -64,14 +67,10 @@ class SacnNode(BaseNode['pyartnet.impl_sacn.SacnUniverse']):
         packet.extend(VECTOR_ROOT_E131_DATA)    # |  4 | Vector
         packet.extend(cid)                      # | 16 | CID, a unique identifier
 
-        # Framing layer Part 1
-        packet.extend([0x72, 0x57])                 # |  2 | Flags and length
-        packet.extend(VECTOR_E131_DATA_PACKET)      # |  4 | Vector
-        packet.extend(source_name_byte)             # | 64 |Source Name
-        packet.append(100)                          # |  1 |Priority
-        packet.extend(int(50).to_bytes(2, 'big'))   # |  2 | Synchronization universe
-
         self._packet_base: bytearray = packet
+
+        self._synchronization_address : int = 0
+        self._sync_sequence_number : int = 0
 
 
     def _send_universe(self, id: int, byte_size: int, values: bytearray,
@@ -80,6 +79,13 @@ class SacnNode(BaseNode['pyartnet.impl_sacn.SacnUniverse']):
 
         # DMX Start Code is not included in the byte size from the universe
         prop_count = byte_size + 1
+
+        # Framing layer Part 1
+        packet.extend((( 87 + prop_count) | 0x7000).to_bytes(2, 'big'))   # Flags and Length
+        packet.extend(VECTOR_E131_DATA_PACKET)      # |  4 | Vector
+        packet.extend(self._source_name_byte)             # | 64 |Source Name
+        packet.append(100)                          # |  1 |Priority
+        packet.extend(int(self._synchronization_address).to_bytes(2, 'big'))    # |  2 | Synchronization universe
 
         # Framing layer Part 2
         packet.append(universe._sequence_ctr.value)             # | 1 | Sequence,
@@ -101,7 +107,6 @@ class SacnNode(BaseNode['pyartnet.impl_sacn.SacnUniverse']):
         # Update length for base packet
         base_packet = self._packet_base
         base_packet[16:18] = ((109 + prop_count) | 0x7000).to_bytes(2, 'big')   # root layer
-        base_packet[38:40] = (( 87 + prop_count) | 0x7000).to_bytes(2, 'big')   # framing layer
 
         self._send_data(packet)
 
@@ -114,3 +119,39 @@ class SacnNode(BaseNode['pyartnet.impl_sacn.SacnUniverse']):
         if not 1 <= nr < 63_999:
             raise InvalidUniverseAddressError()
         return pyartnet.impl_sacn.SacnUniverse(self, nr)
+
+    def set_synchronous_mode(self, enabled: bool, synchronization_address : int = 0):
+        if enabled:
+            assert(synchronization_address != 0)
+            self._synchronization_address = synchronization_address
+        else:
+            assert(synchronization_address == 0)
+            self._synchronization_address = 0
+
+    def _send_synchronization(self):
+        if (self._synchronization_address == 0):
+            return
+
+        packet = bytearray()
+
+        try:
+            base_packet = self._packet_base
+            base_packet[16:18] = ((33) | 0x7000).to_bytes(2, 'big')   # root layer
+            base_packet[18:22] = VECTOR_ROOT_E131_EXTENDED
+            # Framing layer
+            packet.extend(((11) | 0x7000).to_bytes(2, 'big'))                       # |  2 | Flags and Length
+            packet.extend(VECTOR_E131_EXTENDED_SYNCHRONIZATION)                     # |  4 | Vector
+            self._sync_sequence_number += 1
+            if (self._sync_sequence_number >= 255):
+                self._sync_sequence_number = 0
+            packet.append(self._sync_sequence_number)                                    # |  1 | Sequence Number
+            packet.extend(self._synchronization_address.to_bytes(2, 'big'))    # |  2 | Synchronization universe
+            packet.extend([0, 0])                                                   # |  2 | Reserved
+
+            self._send_data(packet)
+
+            if log.isEnabledFor(LVL_DEBUG):
+                # log complete packet
+                log.debug(f"Sending sACN Syncronization Packet to {self._ip}:{self._port}: {(base_packet + packet).hex()}")
+        finally:
+            self._packet_base[18:22] = VECTOR_ROOT_E131_DATA

--- a/tests/test_impl/test_sacn.py
+++ b/tests/test_impl/test_sacn.py
@@ -16,7 +16,30 @@ async def test_sacn(patched_socket):
 
     data = '001000004153432d45312e31370000007078000000044168f52b1a7b2de11712e9ee383d225870620000000264656661756c7420' \
            '736f75726365206e616d650000000000000000000000000000000000000000000000000000000000000000000000000000000000' \
-           '0000000064003200000001701502a100000001000b000102030405060708090a'
+           '0000000064000000000001701502a100000001000b000102030405060708090a'
+
+    m = sacn._socket
+    m.sendto.assert_called_once_with(bytearray(a2b_hex(data)), ('ip', 9999999))
+
+
+    await channel
+
+async def test_sacn_with_sync(patched_socket):
+    sacn = SacnNode(
+        'ip', 9999999,
+        cid=b'\x41\x68\xf5\x2b\x1a\x7b\x2d\xe1\x17\x12\xe9\xee\x38\x3d\x22\x58',
+        source_name="default source name")
+    universe = sacn.add_universe(1)
+    channel = universe.add_channel(1, 10)
+    channel.set_values(range(1, 11))
+
+    sacn.set_synchronous_mode(True, 1)
+
+    universe.send_data()
+
+    data = '001000004153432d45312e31370000007078000000044168f52b1a7b2de11712e9ee383d225870620000000264656661756c7420' \
+           '736f75726365206e616d650000000000000000000000000000000000000000000000000000000000000000000000000000000000' \
+           '0000000064000100000001701502a100000001000b000102030405060708090a'
 
     m = sacn._socket
     m.sendto.assert_called_once_with(bytearray(a2b_hex(data)), ('ip', 9999999))


### PR DESCRIPTION
Implements #49 

Thus far I've only tested the sACN implementation against my hacked version of the python sacn module (and there the sync packets are decoded correctly  with the unmodified SyncPacket class).

I've verified the ArtSync packet is sent and looks right, but I've not tested it against a proper implementation yet. I've hacked python_artnet to find ArtSync's opcode and logs the packet.

This could be a breaking change. Previously the sACN Data packets were sent with sync. address 50. If another sender sent the sync packets for that sync address this will change how the system works. It seems rather far fetched though. Now 0 (no sync) is the default.

An open question is if SacnNode.set_synchronous_mode should be as strict as it is, or if it should allow turning off sync, but keeping a sync address. That could be used to keep the old behaviour of sending packets with sync address 50 without sending the sync packet, but I don't know in what case that would really be useful.

Feel free to make whatever changes you want or ask for changes.